### PR TITLE
Fix typos in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Install
 Clone this repository and run `composer install`
 
-## Show comma is not begin escaped
+## Show comma is not being escaped
 ```
 $ php bin/console postmark-name-comma-not-escaped
 ```
@@ -11,5 +11,5 @@ $ php bin/console postmark-name-comma-not-escaped
 ## Optional: Testing with Postmark 
 1. Uncomment lines 30-36 in `src/Command/PostmarkNameCommaNotEscaped.php`.
 2. Fill in your own from and to email addresses.
-3. Create a .env.local with a MAILER_DSN container your Postmark Server Token.
+3. Create a .env.local with a MAILER_DSN containing your Postmark Server Token.
 4. Run the command `php bin/console postmark-name-comma-not-escaped`


### PR DESCRIPTION
## Summary
- fix README instructions: 'begin' -> 'being'
- fix README instructions: 'container' -> 'containing'

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68542025ed908321b0c55a0c7cae9a4b